### PR TITLE
Rename config option for API key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /.vscode
 /vendor
 .phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Next step is require the package to our project, execute :
 composer require josmlt/spoonacular-laravel-wrapper
 ```
 
-We'll see the messagge: `Installing josmlt/spoonacular-laravel-wrapper (dev-master): Junctioning from ../spoon-wrapper`
+We'll see the message: `Installing josmlt/spoonacular-laravel-wrapper (dev-master): Junctioning from ../spoon-wrapper`
 
 Then execute the follow command, it publishes the config file :
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Then execute the follow command, it publishes the config file :
 php artisan vendor:publish --tag=spoonacular
 ```
 
-Finally we have two options, first we could have a default value of API_KEY, within `config/spoonacular.php` or as well we can add in our `.env` a new environment variable like `API_KEY = ""`
+Finally we have two options, first we could have a default value of SPOONACULAR_API_KEY, within `config/spoonacular.php` or as well we can add in our `.env` a new environment variable like `SPOONACULAR_API_KEY = ""`
     
 ### From Packagist
 We need to pull the package from packagist to our Laravel project.
@@ -78,7 +78,7 @@ Finally we move into :
 config/spoonacular.php
 ```
 
-And add our api key from [Spoonacular](https://spoonacular.com/), or alternative you can create a new environment variable named like `API_KEY`.
+And add our api key from [Spoonacular](https://spoonacular.com/), or alternative you can create a new environment variable named like `SPOONACULAR_API_KEY`.
 
 ## How to use it
 If we want to get recipes with tomato, for example, we just need to search recipes with this keyword, type:

--- a/src/Facades/Spoonacular.php
+++ b/src/Facades/Spoonacular.php
@@ -38,8 +38,8 @@ class Spoonacular
      */
     private function getData(string $endpoint, array $query = null): object|array
     {
-        $api_key = ['apiKey' => config('spoonacular.api_key')];
-        $query == null ? $queryParameters = $api_key : $queryParameters = array_merge($api_key, $query);
+        $apiKey = ['apiKey' => config('spoonacular.api.key')];
+        $query == null ? $queryParameters = $apiKey : $queryParameters = array_merge($apiKey, $query);
 
         return json_decode(
             $this->client

--- a/src/config/spoonacular.php
+++ b/src/config/spoonacular.php
@@ -11,7 +11,9 @@
 */
 
 return [
-    'api_key' => env('API_KEY', ''),
+    'api' => [
+        'key' => env('SPOONACULAR_API_KEY', ''),
+    ],
 
     'providers' => [
         /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,11 +6,11 @@ namespace Josmlt\SpoonacularLaravelWrapper\Tests;
 class TestCase extends \Orchestra\Testbench\TestCase
 {
     /**
-     * Default configuration I want to set, like API_KEY for testing
+     * Default configuration I want to set, like SPOONACULAR_API_KEY for testing
      */
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('spoonacular.api_key', env('API_KEY', ''));
+        $app['config']->set('spoonacular.api.key', env('SPOONACULAR_API_KEY', ''));
     }
 
     /**


### PR DESCRIPTION
Change the name of API_KEY to SPOONACULAR_API_KEY to make sure the env variable is always unique and obvious. Problems occur when integrating with other APIs such as NutritionX, Twilio, FitBit, etc because of variable name conflict/ambiguity. 